### PR TITLE
[BUG] StyleLoss 생성자 수정 및 forward 연산 시 입력 변수 추가

### DIFF
--- a/loss.py
+++ b/loss.py
@@ -17,15 +17,11 @@ class ContentLoss(nn.Module):
 class StyleLoss(nn.Module):
     def __init__(
         self,
-        current_style_feature_maps,
-        target_style_feature_maps,
         style_feature_maps_num,
         gram_normalize=True,
     ):
         super(StyleLoss, self).__init__()
         self.gram_normalize = gram_normalize
-        self.current_style_feature_maps = current_style_feature_maps
-        self.target_style_feature_maps = target_style_feature_maps
         self.style_feature_maps_num = style_feature_maps_num
 
     def gram_matrix(self, input: torch.Tensor):
@@ -37,14 +33,9 @@ class StyleLoss(nn.Module):
             gram /= ch * h * w
         return gram
 
-    def forward(self):
-        current_style_representation = [
-            self.gram_matrix(x) for x in self.current_style_feature_maps
-        ]
-
-        target_style_representation = [
-            self.gram_matrix(x) for x in self.target_style_feature_maps
-        ]
+    def forward(self, input, target):
+        current_style_representation = [self.gram_matrix(x) for x in input]
+        target_style_representation = [self.gram_matrix(x) for x in target]
 
         style_loss = 0.0
         for gram_x, gram_y in zip(


### PR DESCRIPTION
#5

## Overview
- 기존 StyleLoss는 생성 당시 모델의 출력을 입력으로 사용해야 하는 문제가 있어
- loss 계산을 진행할 때 모델 출력을 입력으로 받도록 수정합니다.

## Change Log
- StyleLoss 클래스의 생성자, forward 함수의 입력 변수

## Issue Tags
- Closed | Fixed: #5 
- see also: #
