### PR TITLE
[BUG] StyleLoss-forward 평균 구하는 연산 변수 수정

### DIFF
--- a/loss.py
+++ b/loss.py
@@ -42,5 +42,5 @@ class StyleLoss(nn.Module):
             current_style_representation, target_style_representation
         ):
             style_loss += torch.nn.MSELoss(reduction="sum")(gram_x, gram_y)
-        style_loss /= len(self.style_feature_maps_num)
+        style_loss /= self.style_feature_maps_num
         return style_loss


### PR DESCRIPTION
#7

## Overview
- StyleLoss의 MSE 연산 중 평균을 계산할 때, int 자료형에 len() 함수를 사용해 수정합니다.

## Change Log
-

## Issue Tags
- Closed | Fixed: #7 
- see also: #
